### PR TITLE
Set dependencies in setup.py

### DIFF
--- a/bruco/functions.py
+++ b/bruco/functions.py
@@ -1,8 +1,6 @@
 # Brute force coherence (Gabriele Vajente, 2015-06-09)
 
-import nds2
 import numpy
-import os
 from pylab import *
 import time
 from scipy.signal import cheby1, lfilter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+scipy
+matplotlib
+http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,16 @@ setup(name=DISTNAME,
       include_package_data=True,
       scripts=scripts,
       requires=[
+          'numpy',
+          'scipy',
+          'matplotlib',
+          'glue',
+          'pylal',
       ],
       install_requires=[
+      ],
+      dependency_links=[
+          'http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz',
       ],
       use_2to3=True,
       classifiers=[


### PR DESCRIPTION
This PR adds the list of dependencies to `setup.py` and `requirements.txt` and removes a couple of unused imports in `bruco/functions.py`.

The main outstanding packaging problem is the use of `pylal`. This package is readily available on the LDG, but isn't setup correctly to be installable automatically using pip (for other users). For this reason I haven't declared it in `setup.py` or `requirements.txt`, hopefully users can figure that out on their own (for now).