### PR TITLE
Corrected author listing in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ finally:
 # set basic metadata
 PACKAGENAME = 'bruco'
 DISTNAME = 'bruco'
-AUTHOR = 'Duncan Macleod'
-AUTHOR_EMAIL = 'duncan.macleod@ligo.org'
+AUTHOR = 'Gabriele Vajente'
+AUTHOR_EMAIL = 'gabriele.vajente@ligo.org'
 LICENSE = 'GPLv3'
 
 # Use the find_packages tool to locate all packages and modules


### PR DESCRIPTION
This commit fixes the `author` and `author_email` listings in the `setup.py` file.
